### PR TITLE
Improve login click-through reliability and error guidance

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -20,11 +20,23 @@ export default function Login() {
 
   const handleLogin = async () => {
     setError('');
+    const normalizedEmail = email.trim().toLowerCase();
+
+    if (!normalizedEmail || !password) {
+      setError('Please enter both your email and password.');
+      return;
+    }
+
     setLoading(true);
-    const result = await login(email, password);
+    const result = await login(normalizedEmail, password);
     setLoading(false);
+
     if (result.error) {
-      setError(result.error);
+      if (result.error.toLowerCase().includes('invalid login credentials')) {
+        setError('We could not sign you in. Double-check your email/password or reset your password if needed.');
+      } else {
+        setError(result.error);
+      }
     }
     // Navigation happens via auth state change + redirect logic in pages
   };
@@ -39,31 +51,39 @@ export default function Login() {
           <h1 className="text-2xl font-bold text-card-foreground">Welcome back</h1>
           <p className="text-sm text-muted-foreground mt-1">Sign in to your GameplanIT account</p>
         </div>
-        <div className="space-y-3">
+        <form
+          className="space-y-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void handleLogin();
+          }}
+        >
           <input
             className="w-full rounded-lg border border-input bg-background px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            type="email"
+            autoComplete="email"
+            autoCapitalize="none"
             placeholder="Email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && handleLogin()}
           />
           <input
             className="w-full rounded-lg border border-input bg-background px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
             type="password"
+            autoComplete="current-password"
             placeholder="Password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && handleLogin()}
           />
-        </div>
-        {error && <p className="text-sm text-destructive">{error}</p>}
-        <button
-          className="w-full rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50"
-          onClick={handleLogin}
-          disabled={loading}
-        >
-          {loading ? 'Signing in...' : 'Sign in'}
-        </button>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <button
+            type="submit"
+            className="w-full rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50"
+            disabled={loading}
+          >
+            {loading ? 'Signing in...' : 'Sign in'}
+          </button>
+        </form>
         <p className="text-center text-sm text-muted-foreground">
           Don't have an account?{' '}
           <Link to="/onboarding" className="text-primary font-medium hover:underline">Get started</Link>


### PR DESCRIPTION
### Motivation
- Users reported the login flow was not reliably submitting when clicking the button or pressing Enter, causing a bad sign-in experience. 
- Input formatting (leading/trailing spaces, case) can cause avoidable failed sign-ins. 
- The raw auth error was not user-friendly and didn’t provide clear next steps when credentials were rejected.

### Description
- Replaced per-input Enter handlers with a semantic `<form>` and `onSubmit` to ensure Enter and button clicks consistently trigger auth (`src/pages/Login.tsx`).
- Normalize email before auth by trimming and lowercasing it and add client-side validation to block empty submissions.
- Map invalid-credential responses to a clearer user-facing message suggesting rechecking credentials or resetting the password, while preserving other error text.
- Added input attributes to improve autofill and mobile behavior: `type="email"`, `autoComplete`, and `autoCapitalize="none"` for the email field and `autoComplete="current-password"` for the password field.

### Testing
- Ran the test suite with `npm test` (`vitest`) and all tests passed.
- Built the production bundle with `npm run build` and the build completed successfully.
- Executed a Playwright check against the running dev server to simulate filling the form (including trimmed/cased email) and confirmed the form submits and shows the improved credential guidance; a screenshot was captured for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999cc94a21c832191d3bd98c7720c87)