### PR TITLE
Homepage: add personalized feed & progressive preview; add privacy/terms/contact pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,13 +15,14 @@ import OpportunitiesPage from './pages/OpportunitiesPage';
 import PracticePage from './pages/PracticePage';
 import CertsProofPage from './pages/CertsProofPage';
 import SupportPage from './pages/SupportPage';
-import PageNav from './components/PageNav';
+import PrivacyPolicy from './pages/PrivacyPolicy';
+import TermsOfService from './pages/TermsOfService';
+import Contact from './pages/Contact';
 
 export default function App() {
   return (
     <AuthProvider>
       <BrowserRouter>
-        <PageNav />
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/login" element={<Login />} />
@@ -35,6 +36,9 @@ export default function App() {
           <Route path="/practice" element={<PracticePage />} />
           <Route path="/certs" element={<CertsProofPage />} />
           <Route path="/support" element={<SupportPage />} />
+          <Route path="/privacy" element={<PrivacyPolicy />} />
+          <Route path="/terms" element={<TermsOfService />} />
+          <Route path="/contact" element={<Contact />} />
           <Route path="/explore-careers" element={<ExploreCareers />} />
           <Route path="/partner" element={<Partner />} />
           <Route path="/partner/resources" element={<ResourceAdmin />} />

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,0 +1,22 @@
+export default function Contact() {
+  return (
+    <main className="min-h-screen bg-background py-16 px-6">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <h1 className="text-3xl font-bold text-foreground">Contact</h1>
+        <p className="text-muted-foreground">
+          Questions about student plans, partnerships, or support? Reach us and we will follow up within 2 business days.
+        </p>
+
+        <div className="rounded-lg border border-border bg-card p-6 space-y-3">
+          <p className="text-sm text-muted-foreground">General support</p>
+          <p className="text-lg font-semibold text-foreground">support@gameplanit.org</p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-6 space-y-3">
+          <p className="text-sm text-muted-foreground">Partnership inquiries</p>
+          <p className="text-lg font-semibold text-foreground">partners@gameplanit.org</p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   BookOpen, Shield, Users, Clock, Target, Sparkles,
@@ -93,7 +94,38 @@ const sampleWeek = {
   milestone: 'Week 3 milestone: Identify 2 STEM paths that interest you.',
 };
 
+const audienceFeed = {
+  student: {
+    label: 'Student feed',
+    items: [
+      'Because you said Algebra + 2 hours/week: 3 short actions for this week.',
+      'Recommended next: no-cost STEM workshop available this Saturday.',
+      'Continue where you left off: 1 action remaining (about 20 minutes).',
+    ],
+  },
+  caregiver: {
+    label: 'Caregiver feed',
+    items: [
+      'This week at a glance: 3 tasks your student can finish at home.',
+      'Suggested check-in prompt: “What did you learn from the career quiz?”',
+      'Upcoming milestone: confirm one mentor conversation by Friday.',
+    ],
+  },
+  partner: {
+    label: 'Partner feed',
+    items: [
+      'Priority cohort trend: 9th grade attendance barriers rose this week.',
+      'Recommended intervention: transportation-friendly resource bundle.',
+      'Impact snapshot: 68% of active users completed at least 2 weekly actions.',
+    ],
+  },
+} as const;
+
 export default function Index() {
+  const [selectedAudience, setSelectedAudience] = useState<keyof typeof audienceFeed>('student');
+  const [showFullPreview, setShowFullPreview] = useState(false);
+  const selectedFeed = useMemo(() => audienceFeed[selectedAudience], [selectedAudience]);
+
   return (
     <div className="min-h-screen bg-background">
       {/* ─── HERO ─── */}
@@ -141,8 +173,61 @@ export default function Index() {
           <p className="mt-4 text-sm text-muted-foreground">
             Takes ~3 minutes. Free to start. No credit card required.
           </p>
+
+          <div className="mt-6 flex flex-wrap justify-center gap-2 text-xs">
+            {['Personalized in under 3 minutes', 'No credit card required', 'Built for mobile + low bandwidth'].map((chip) => (
+              <span key={chip} className="rounded-full border border-border bg-card/70 px-3 py-1.5 text-muted-foreground">
+                {chip}
+              </span>
+            ))}
+          </div>
         </div>
       </header>
+
+      {/* ─── PERSONALIZED FEED PREVIEW ─── */}
+      <section className="py-14 bg-background">
+        <div className="max-w-4xl mx-auto px-6">
+          <h2 className="text-2xl font-bold text-foreground text-center mb-2">See your personalized feed</h2>
+          <p className="text-sm text-muted-foreground text-center mb-8">
+            Inspired by streaming-style personalization: pick your role and preview what your next-best actions look like.
+          </p>
+
+          <div className="flex flex-wrap justify-center gap-2 mb-6">
+            {[
+              ['student', 'Student'],
+              ['caregiver', 'Caregiver'],
+              ['partner', 'Partner'],
+            ].map(([key, label]) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setSelectedAudience(key as keyof typeof audienceFeed)}
+                className={`rounded-full px-4 py-2 text-sm border transition-colors ${
+                  selectedAudience === key
+                    ? 'bg-primary text-primary-foreground border-primary'
+                    : 'bg-card text-muted-foreground border-border hover:text-foreground'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          <Card className="border-border shadow-sm">
+            <CardContent className="pt-6">
+              <h3 className="font-semibold text-foreground mb-4">{selectedFeed.label}</h3>
+              <ul className="space-y-3">
+                {selectedFeed.items.map((item) => (
+                  <li key={item} className="text-sm text-muted-foreground flex gap-2">
+                    <CheckCircle2 className="w-4 h-4 mt-0.5 text-primary shrink-0" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
 
       {/* ─── HOW IT WORKS ─── */}
       <section className="py-20 bg-secondary/30">
@@ -259,7 +344,7 @@ export default function Index() {
                     <ListChecks className="w-3.5 h-3.5" /> Actions
                   </h4>
                   <ul className="space-y-2">
-                    {sampleWeek.actions.map((a, i) => (
+                    {(showFullPreview ? sampleWeek.actions : sampleWeek.actions.slice(0, 2)).map((a, i) => (
                       <li key={i} className="flex gap-2 text-sm text-foreground">
                         <span className="w-5 h-5 rounded border border-border flex items-center justify-center shrink-0 mt-0.5 text-xs text-muted-foreground">{i + 1}</span>
                         {a}
@@ -276,7 +361,7 @@ export default function Index() {
                     <div>
                       <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-1">How to access</p>
                       <ol className="list-decimal list-inside space-y-0.5">
-                        {sampleWeek.featuredResource.access.map((s, i) => (
+                        {(showFullPreview ? sampleWeek.featuredResource.access : sampleWeek.featuredResource.access.slice(0, 2)).map((s, i) => (
                           <li key={i} className="text-sm text-muted-foreground">{s}</li>
                         ))}
                       </ol>
@@ -307,6 +392,13 @@ export default function Index() {
                     </h4>
                     <p className="text-sm text-foreground">{sampleWeek.milestone}</p>
                   </div>
+                  <button
+                    type="button"
+                    onClick={() => setShowFullPreview(prev => !prev)}
+                    className="mt-4 text-sm font-medium text-primary hover:underline"
+                  >
+                    {showFullPreview ? 'Show concise preview' : 'Show full week details'}
+                  </button>
                 </div>
               </div>
             </CardContent>
@@ -377,9 +469,9 @@ export default function Index() {
               <span className="font-semibold text-foreground">GameplanIT</span>
             </div>
             <nav className="flex flex-wrap justify-center gap-x-6 gap-y-2 text-sm text-muted-foreground">
-              <a href="#" className="hover:text-foreground transition-colors">Privacy</a>
-              <a href="#" className="hover:text-foreground transition-colors">Terms</a>
-              <a href="#" className="hover:text-foreground transition-colors">Contact</a>
+              <Link to="/privacy" className="hover:text-foreground transition-colors">Privacy</Link>
+              <Link to="/terms" className="hover:text-foreground transition-colors">Terms</Link>
+              <Link to="/contact" className="hover:text-foreground transition-colors">Contact</Link>
               <Link to="/partner" className="hover:text-foreground transition-colors flex items-center gap-1">
                 <Mail className="w-3.5 h-3.5" /> Partner Inquiry
               </Link>

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,37 @@
+export default function PrivacyPolicy() {
+  return (
+    <main className="min-h-screen bg-background py-16 px-6">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <h1 className="text-3xl font-bold text-foreground">Privacy Policy</h1>
+        <p className="text-muted-foreground">
+          GameplanIT is built to protect student and family information. We only collect information needed to generate and improve personalized learning plans.
+        </p>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">What we collect</h2>
+          <ul className="list-disc pl-5 text-muted-foreground space-y-1">
+            <li>Goal details (for example: subject, timeline, preferred outcomes).</li>
+            <li>Planning constraints (schedule, budget, and transportation preferences).</li>
+            <li>Basic account details when users create an account.</li>
+          </ul>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">How we use data</h2>
+          <ul className="list-disc pl-5 text-muted-foreground space-y-1">
+            <li>Generate personalized 12-week plans.</li>
+            <li>Improve recommendations and resource matching.</li>
+            <li>Provide anonymized, aggregate insights for partner organizations.</li>
+          </ul>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Data protection</h2>
+          <p className="text-muted-foreground">
+            We do not sell personal information. Partner reporting is anonymized and aggregated so individuals are not identified.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -1,0 +1,35 @@
+export default function TermsOfService() {
+  return (
+    <main className="min-h-screen bg-background py-16 px-6">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <h1 className="text-3xl font-bold text-foreground">Terms of Service</h1>
+        <p className="text-muted-foreground">
+          By using GameplanIT, you agree to use the platform responsibly and provide accurate information so plans can be personalized effectively.
+        </p>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Platform purpose</h2>
+          <p className="text-muted-foreground">
+            GameplanIT provides educational planning guidance and curated resources. It is not a guarantee of admission, employment, or academic outcomes.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">User responsibilities</h2>
+          <ul className="list-disc pl-5 text-muted-foreground space-y-1">
+            <li>Provide truthful planning details.</li>
+            <li>Use the platform in lawful and respectful ways.</li>
+            <li>Do not attempt to access data that is not yours.</li>
+          </ul>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Updates</h2>
+          <p className="text-muted-foreground">
+            We may update these terms as the product evolves. Continued use after updates indicates acceptance.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide real, discoverable legal and support pages so the footer no longer links to dead anchors and the product shows proper trust signals for launch readiness.
- Improve first-glance information intake by introducing a streaming-style, role-targeted preview so visitors can quickly see relevant next-best actions for Students, Caregivers, or Partners.
- Simplify the app shell and reduce debug-like UI by removing the floating `PageNav` control for a more polished production impression.

### Description
- Added `src/pages/PrivacyPolicy.tsx`, `src/pages/TermsOfService.tsx`, and `src/pages/Contact.tsx` and registered `/privacy`, `/terms`, and `/contact` routes in `src/App.tsx`.
- Replaced footer `#` anchors with internal `Link` components in `src/pages/Index.tsx` so Privacy, Terms, and Contact navigate to the new pages.
- Implemented an interactive personalized feed in `src/pages/Index.tsx` by introducing the `audienceFeed` constant, `useState`/`useMemo` for selection, and role toggle buttons to preview Student/Caregiver/Partner items.
- Added compact trust/value chips under the hero and a progressive-disclosure toggle (`showFullPreview`) in the plan preview so the page shows a concise preview by default and expands to full week details on demand, and removed the `PageNav` import/usage.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npm test` and all automated tests passed (`25` tests across `3` files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a38ce1fbc832183a72753edac78c7)