### PR TITLE
Improve explore page with search, filtering, and better UX

### DIFF
--- a/src/components/explore/CareerPathMap.tsx
+++ b/src/components/explore/CareerPathMap.tsx
@@ -324,6 +324,20 @@ function CareerNode({
         </div>
       </div>
 
+      {/* Tag chips */}
+      {path.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-1.5">
+          {path.tags.slice(0, variant === 'selected' ? 3 : 2).map(tag => (
+            <span
+              key={tag}
+              className="text-[9px] font-medium text-muted-foreground bg-secondary rounded-full px-1.5 py-0.5"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
       {variant !== 'selected' && (
         <div className="flex items-center gap-1 mt-2 text-[10px] text-primary">
           <span>Explore</span>

--- a/src/components/explore/CareerPreviewPanel.tsx
+++ b/src/components/explore/CareerPreviewPanel.tsx
@@ -1,5 +1,5 @@
 import type { CareerPath } from '@/lib/types';
-import { Compass, Wrench, FolderOpen, Rocket, ArrowRight, Star, TrendingUp, Shuffle } from 'lucide-react';
+import { Compass, Wrench, FolderOpen, Rocket, ArrowRight, Star, TrendingUp, Shuffle, Tag } from 'lucide-react';
 
 interface Props {
   path: CareerPath;
@@ -15,6 +15,22 @@ const stages = [
   { label: 'Build Proof', icon: FolderOpen, desc: 'Create portfolio pieces, certifications, or real-world projects.' },
   { label: 'Apply / Unlock', icon: Rocket, desc: 'Apply for opportunities and unlock next-level experiences.' },
 ];
+
+function generateWhyItMatters(path: CareerPath): string {
+  const hasNextLevel = path.nextLevelCareerIds.length > 0;
+  const hasRelated = path.relatedCareerIds.length > 0;
+
+  if (hasNextLevel && hasRelated) {
+    return `${path.name} opens doors to advanced roles and connects to related fields. The skills you build here are transferable and valued across industries.`;
+  }
+  if (hasNextLevel) {
+    return `${path.name} is a strong foundation that leads to more advanced career opportunities. Each step builds toward higher-level positions.`;
+  }
+  if (hasRelated) {
+    return `${path.name} connects to multiple related careers, giving you flexibility to pivot or specialize as you discover what fits you best.`;
+  }
+  return `${path.name} builds real-world skills that employers value. Every step you take creates momentum toward meaningful work.`;
+}
 
 export default function CareerPreviewPanel({ path, allPaths, isCurrentPath, onStartPath, onSelectRelated }: Props) {
   const relatedPaths = path.relatedCareerIds
@@ -44,6 +60,20 @@ export default function CareerPreviewPanel({ path, allPaths, isCurrentPath, onSt
             )}
           </div>
         </div>
+        {/* Tags */}
+        {path.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-3">
+            {path.tags.map(tag => (
+              <span
+                key={tag}
+                className="inline-flex items-center gap-1 text-[10px] font-medium text-muted-foreground bg-background/60 rounded-full px-2 py-0.5"
+              >
+                <Tag className="w-2.5 h-2.5" />
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="p-5 space-y-5">
@@ -55,13 +85,13 @@ export default function CareerPreviewPanel({ path, allPaths, isCurrentPath, onSt
           <p className="text-sm text-card-foreground leading-relaxed">{path.description}</p>
         </section>
 
-        {/* Why It Matters */}
+        {/* Why It Matters — dynamic per career */}
         <section>
           <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1.5">
             Why It Matters
           </h4>
           <p className="text-sm text-card-foreground leading-relaxed">
-            This career helps you make an impact while building skills that are in demand. Every step you take builds toward real opportunities.
+            {generateWhyItMatters(path)}
           </p>
         </section>
 
@@ -71,7 +101,9 @@ export default function CareerPreviewPanel({ path, allPaths, isCurrentPath, onSt
             <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1.5">
               Education Path Options
             </h4>
-            <p className="text-sm text-card-foreground">📚 {path.recommendedEducationNotes}</p>
+            <p className="text-sm text-card-foreground leading-relaxed">
+              {path.recommendedEducationNotes}
+            </p>
           </section>
         )}
 

--- a/src/pages/ExploreCareers.tsx
+++ b/src/pages/ExploreCareers.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 import { storage } from '@/lib/storage';
@@ -8,7 +8,7 @@ import CareerPathMap from '@/components/explore/CareerPathMap';
 import CareerPreviewPanel from '@/components/explore/CareerPreviewPanel';
 import { fetchCareerDomains, fetchCareerPaths } from '@/lib/careerService';
 import type { CareerDomain, CareerPath } from '@/lib/types';
-import { Loader2 } from 'lucide-react';
+import { Search, X, ArrowLeft, Compass, ArrowRight } from 'lucide-react';
 
 const domainEmojis: Record<string, string> = {
   'Healthcare': '🏥',
@@ -19,6 +19,15 @@ const domainEmojis: Record<string, string> = {
   'Public Service': '🏛️',
 };
 
+const domainDescriptions: Record<string, string> = {
+  'Healthcare': 'Medicine, nursing, therapy & wellness',
+  'Technology': 'Software, data, cybersecurity & IT',
+  'Business & Entrepreneurship': 'Finance, marketing & startups',
+  'Creative & Media': 'Design, film, music & content',
+  'Skilled Trades': 'Construction, electrical & mechanics',
+  'Public Service': 'Government, law & community work',
+};
+
 export default function ExploreCareers() {
   const { user } = useAuth();
   const nav = useNavigate();
@@ -27,6 +36,8 @@ export default function ExploreCareers() {
   const [selectedDomainId, setSelectedDomainId] = useState<string | null>(null);
   const [selectedPathId, setSelectedPathId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeTagFilter, setActiveTagFilter] = useState<string | null>(null);
 
   const profile = user ? storage.allProfiles().find((p) => p.userId === user.id) : undefined;
 
@@ -38,11 +49,66 @@ export default function ExploreCareers() {
     });
   }, []);
 
-  if (!user) return <Navigate to="/login" />;
+  // Search results across all domains
+  const searchResults = useMemo(() => {
+    if (!searchQuery.trim()) return [];
+    const q = searchQuery.toLowerCase();
+    return allCareerPaths.filter(
+      p => p.name.toLowerCase().includes(q) ||
+           p.description.toLowerCase().includes(q) ||
+           p.tags.some(t => t.toLowerCase().includes(q))
+    );
+  }, [searchQuery, allCareerPaths]);
 
-  const domainPaths = selectedDomainId ? allCareerPaths.filter(p => p.domainId === selectedDomainId) : [];
+  const isSearching = searchQuery.trim().length > 0;
+
+  // Domain paths with optional tag filter
+  const domainPaths = useMemo(() => {
+    if (!selectedDomainId) return [];
+    let paths = allCareerPaths.filter(p => p.domainId === selectedDomainId);
+    if (activeTagFilter) {
+      paths = paths.filter(p => p.tags.includes(activeTagFilter));
+    }
+    return paths;
+  }, [selectedDomainId, allCareerPaths, activeTagFilter]);
+
+  // Collect unique tags for the selected domain
+  const domainTags = useMemo(() => {
+    if (!selectedDomainId) return [];
+    const paths = allCareerPaths.filter(p => p.domainId === selectedDomainId);
+    const tagSet = new Set<string>();
+    paths.forEach(p => p.tags.forEach(t => tagSet.add(t)));
+    return Array.from(tagSet).sort();
+  }, [selectedDomainId, allCareerPaths]);
+
+  // Career counts per domain
+  const domainCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    allCareerPaths.forEach(p => {
+      counts[p.domainId] = (counts[p.domainId] || 0) + 1;
+    });
+    return counts;
+  }, [allCareerPaths]);
+
   const selectedPath = selectedPathId ? allCareerPaths.find(p => p.id === selectedPathId) : null;
   const selectedDomain = selectedDomainId ? careerDomains.find(d => d.id === selectedDomainId) : null;
+
+  if (!user) return <Navigate to="/login" />;
+
+  const handleSelectDomain = (domainId: string) => {
+    const isActive = selectedDomainId === domainId;
+    setSelectedDomainId(isActive ? null : domainId);
+    setSelectedPathId(null);
+    setActiveTagFilter(null);
+    setSearchQuery('');
+  };
+
+  const handleSearchSelect = (path: CareerPath) => {
+    setSelectedDomainId(path.domainId);
+    setSelectedPathId(path.id);
+    setSearchQuery('');
+    setActiveTagFilter(null);
+  };
 
   return (
     <SidebarProvider>
@@ -61,82 +127,271 @@ export default function ExploreCareers() {
           </div>
 
           <div className="max-w-5xl mx-auto px-6 py-6 space-y-6">
-            {/* Header */}
-            <div>
-              <h2 className="text-lg font-bold text-card-foreground">Explore Career Paths</h2>
-              <p className="text-sm text-muted-foreground mt-1">
-                Discover how careers connect and find your direction. Pick a domain to see the roadmap.
-              </p>
-            </div>
-
-            {/* Domain tiles */}
-            {loading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 className="w-5 h-5 animate-spin text-primary" />
-                <span className="ml-2 text-sm text-muted-foreground">Loading domains…</span>
+            {/* Header + Search */}
+            <div className="space-y-4">
+              <div>
+                <h2 className="text-lg font-bold text-card-foreground">Explore Career Paths</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Discover how careers connect and find your direction. Pick a domain or search for a career.
+                </p>
               </div>
-            ) : (
-              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-                {careerDomains.map(d => {
-                  const isActive = selectedDomainId === d.id;
-                  return (
-                    <button
-                      key={d.id}
-                      onClick={() => {
-                        setSelectedDomainId(isActive ? null : d.id);
-                        setSelectedPathId(null);
-                      }}
-                      className={`rounded-xl border p-4 text-center transition-all ${
-                        isActive
-                          ? 'border-primary bg-accent ring-1 ring-primary/20 shadow-sm'
-                          : 'border-border hover:border-primary/40 hover:shadow-sm'
-                      }`}
-                    >
-                      <span className="text-2xl block mb-1.5">{domainEmojis[d.name] || '📋'}</span>
-                      <span className={`text-xs font-semibold leading-tight block ${isActive ? 'text-accent-foreground' : 'text-card-foreground'}`}>
-                        {d.name}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            )}
 
-            {/* Career Map + Preview */}
-            {selectedDomainId && domainPaths.length > 0 && (
-              <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
-                <div className="lg:col-span-3">
-                  <CareerPathMap
-                    paths={domainPaths}
-                    allPaths={allCareerPaths}
-                    selectedPathId={selectedPathId}
-                    currentCareerPathId={profile?.careerPathId}
-                    onSelect={setSelectedPathId}
-                    domainName={selectedDomain?.name || ''}
-                  />
-                </div>
-                <div className="lg:col-span-2">
-                  {selectedPath ? (
-                    <CareerPreviewPanel
-                      path={selectedPath}
-                      allPaths={allCareerPaths}
-                      isCurrentPath={profile?.careerPathId === selectedPath.id}
-                      onStartPath={() => nav('/onboarding', { state: { careerPathId: selectedPath.id } })}
-                      onSelectRelated={setSelectedPathId}
-                    />
+              {/* Search bar */}
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={e => setSearchQuery(e.target.value)}
+                  placeholder="Search careers by name, description, or skill..."
+                  className="w-full rounded-lg border border-border bg-card pl-10 pr-10 py-2.5 text-sm text-card-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors"
+                />
+                {searchQuery && (
+                  <button
+                    onClick={() => setSearchQuery('')}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-card-foreground transition-colors"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                )}
+              </div>
+
+              {/* Search results dropdown */}
+              {isSearching && (
+                <div className="rounded-xl border border-border bg-card overflow-hidden">
+                  <div className="px-4 py-2.5 border-b border-border bg-accent/30">
+                    <p className="text-xs font-medium text-muted-foreground">
+                      {searchResults.length} {searchResults.length === 1 ? 'career' : 'careers'} found
+                    </p>
+                  </div>
+                  {searchResults.length > 0 ? (
+                    <div className="max-h-72 overflow-y-auto divide-y divide-border">
+                      {searchResults.map(path => {
+                        const domain = careerDomains.find(d => d.id === path.domainId);
+                        return (
+                          <button
+                            key={path.id}
+                            onClick={() => handleSearchSelect(path)}
+                            className="w-full text-left px-4 py-3 hover:bg-secondary transition-colors flex items-start gap-3"
+                          >
+                            <span className="text-lg shrink-0 mt-0.5">{domainEmojis[domain?.name || ''] || '📋'}</span>
+                            <div className="min-w-0 flex-1">
+                              <p className="text-sm font-semibold text-card-foreground">{path.name}</p>
+                              <p className="text-xs text-muted-foreground line-clamp-1">{path.description}</p>
+                              <div className="flex items-center gap-2 mt-1">
+                                <span className="text-[10px] font-medium text-primary bg-primary/10 rounded-full px-2 py-0.5">
+                                  {domain?.name || 'Unknown'}
+                                </span>
+                                {path.tags.slice(0, 2).map(tag => (
+                                  <span key={tag} className="text-[10px] text-muted-foreground bg-secondary rounded-full px-2 py-0.5">
+                                    {tag}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                            <ArrowRight className="w-4 h-4 text-muted-foreground shrink-0 mt-1" />
+                          </button>
+                        );
+                      })}
+                    </div>
                   ) : (
-                    <div className="rounded-xl border border-dashed border-border bg-card/50 p-8 text-center">
-                      <p className="text-sm text-muted-foreground">👆 Click a career in the map to see details</p>
+                    <div className="px-4 py-8 text-center">
+                      <p className="text-sm text-muted-foreground">No careers match your search. Try different keywords.</p>
                     </div>
                   )}
                 </div>
-              </div>
-            )}
+              )}
+            </div>
 
-            {selectedDomainId && domainPaths.length === 0 && (
-              <div className="rounded-xl border border-dashed border-border bg-card/50 p-8 text-center">
-                <p className="text-sm text-muted-foreground">No career paths found in this domain yet.</p>
-              </div>
+            {/* Domain tiles */}
+            {!isSearching && (
+              <>
+                {loading ? (
+                  <div className="space-y-4">
+                    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+                      {Array.from({ length: 6 }).map((_, i) => (
+                        <div key={i} className="rounded-xl border border-border p-4 animate-pulse">
+                          <div className="w-8 h-8 bg-muted rounded-full mx-auto mb-2" />
+                          <div className="h-3 w-16 bg-muted rounded mx-auto mb-1.5" />
+                          <div className="h-2 w-12 bg-muted rounded mx-auto" />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
+                      <div className="lg:col-span-3 rounded-xl border border-border bg-card p-5 animate-pulse">
+                        <div className="h-4 w-32 bg-muted rounded mb-3" />
+                        <div className="grid grid-cols-2 gap-2">
+                          {Array.from({ length: 4 }).map((_, i) => (
+                            <div key={i} className="h-16 bg-muted rounded-lg" />
+                          ))}
+                        </div>
+                      </div>
+                      <div className="lg:col-span-2 rounded-xl border border-dashed border-border p-8 animate-pulse">
+                        <div className="h-4 w-40 bg-muted rounded mx-auto" />
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+                    {careerDomains.map(d => {
+                      const isActive = selectedDomainId === d.id;
+                      const count = domainCounts[d.id] || 0;
+                      return (
+                        <button
+                          key={d.id}
+                          onClick={() => handleSelectDomain(d.id)}
+                          className={`rounded-xl border p-4 text-center transition-all ${
+                            isActive
+                              ? 'border-primary bg-accent ring-1 ring-primary/20 shadow-sm'
+                              : 'border-border hover:border-primary/40 hover:shadow-sm'
+                          }`}
+                        >
+                          <span className="text-2xl block mb-1.5">{domainEmojis[d.name] || '📋'}</span>
+                          <span className={`text-xs font-semibold leading-tight block ${isActive ? 'text-accent-foreground' : 'text-card-foreground'}`}>
+                            {d.name}
+                          </span>
+                          <span className="text-[10px] text-muted-foreground block mt-1 leading-snug">
+                            {domainDescriptions[d.name] || d.description}
+                          </span>
+                          <span className={`text-[10px] mt-1.5 inline-block rounded-full px-2 py-0.5 font-medium ${
+                            isActive ? 'bg-primary/15 text-primary' : 'bg-secondary text-muted-foreground'
+                          }`}>
+                            {count} {count === 1 ? 'career' : 'careers'}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {/* Selected domain header + tag filters */}
+                {selectedDomainId && !loading && (
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => {
+                            setSelectedDomainId(null);
+                            setSelectedPathId(null);
+                            setActiveTagFilter(null);
+                          }}
+                          className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-card-foreground transition-colors"
+                        >
+                          <ArrowLeft className="w-3 h-3" /> All Domains
+                        </button>
+                        <span className="text-xs text-muted-foreground">/</span>
+                        <span className="text-xs font-semibold text-card-foreground">
+                          {domainEmojis[selectedDomain?.name || ''] || '📋'} {selectedDomain?.name}
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* Tag filter chips */}
+                    {domainTags.length > 1 && (
+                      <div className="flex flex-wrap gap-1.5">
+                        <button
+                          onClick={() => setActiveTagFilter(null)}
+                          className={`text-[11px] font-medium rounded-full px-3 py-1 transition-colors ${
+                            !activeTagFilter
+                              ? 'bg-primary text-primary-foreground'
+                              : 'bg-secondary text-muted-foreground hover:bg-secondary/80'
+                          }`}
+                        >
+                          All
+                        </button>
+                        {domainTags.map(tag => (
+                          <button
+                            key={tag}
+                            onClick={() => setActiveTagFilter(activeTagFilter === tag ? null : tag)}
+                            className={`text-[11px] font-medium rounded-full px-3 py-1 transition-colors ${
+                              activeTagFilter === tag
+                                ? 'bg-primary text-primary-foreground'
+                                : 'bg-secondary text-muted-foreground hover:bg-secondary/80'
+                            }`}
+                          >
+                            {tag}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Career Map + Preview */}
+                {selectedDomainId && domainPaths.length > 0 && (
+                  <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
+                    <div className="lg:col-span-3">
+                      <CareerPathMap
+                        paths={domainPaths}
+                        allPaths={allCareerPaths}
+                        selectedPathId={selectedPathId}
+                        currentCareerPathId={profile?.careerPathId}
+                        onSelect={setSelectedPathId}
+                        domainName={selectedDomain?.name || ''}
+                      />
+                    </div>
+                    <div className="lg:col-span-2">
+                      {selectedPath ? (
+                        <CareerPreviewPanel
+                          path={selectedPath}
+                          allPaths={allCareerPaths}
+                          isCurrentPath={profile?.careerPathId === selectedPath.id}
+                          onStartPath={() => nav('/onboarding', { state: { careerPathId: selectedPath.id } })}
+                          onSelectRelated={setSelectedPathId}
+                        />
+                      ) : (
+                        <div className="rounded-xl border border-dashed border-border bg-card/50 p-8 text-center space-y-3">
+                          <Compass className="w-8 h-8 text-muted-foreground/40 mx-auto" />
+                          <div>
+                            <p className="text-sm font-medium text-card-foreground">Select a career</p>
+                            <p className="text-xs text-muted-foreground mt-1">
+                              Click any career in the map to see what the path looks like, what you'll learn, and where it can lead.
+                            </p>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {selectedDomainId && domainPaths.length === 0 && !loading && (
+                  <div className="rounded-xl border border-dashed border-border bg-card/50 p-8 text-center space-y-2">
+                    <p className="text-sm text-muted-foreground">
+                      {activeTagFilter
+                        ? `No careers match the "${activeTagFilter}" filter in this domain.`
+                        : 'No career paths found in this domain yet.'}
+                    </p>
+                    {activeTagFilter && (
+                      <button
+                        onClick={() => setActiveTagFilter(null)}
+                        className="text-xs text-primary hover:underline"
+                      >
+                        Clear filter
+                      </button>
+                    )}
+                  </div>
+                )}
+
+                {/* Initial guidance when no domain selected */}
+                {!selectedDomainId && !loading && (
+                  <div className="rounded-xl border border-border bg-card/50 p-6">
+                    <div className="flex items-start gap-4">
+                      <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+                        <Compass className="w-5 h-5 text-primary" />
+                      </div>
+                      <div>
+                        <h3 className="text-sm font-semibold text-card-foreground">How to explore</h3>
+                        <ol className="text-xs text-muted-foreground mt-2 space-y-1.5 list-decimal list-inside">
+                          <li>Pick a domain above that interests you</li>
+                          <li>Browse careers and click one to see its roadmap</li>
+                          <li>See how careers connect — where they lead and what's related</li>
+                          <li>When you find the right fit, start your 12-week path</li>
+                        </ol>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </>
             )}
           </div>
         </main>


### PR DESCRIPTION
- Add cross-domain career search bar with live results dropdown
- Add career count badges and short descriptions to domain tiles
- Add tag-based filter chips within selected domains
- Add breadcrumb navigation with "Back to all domains" button
- Replace spinner loading state with skeleton UI matching Dashboard
- Make "Why It Matters" section dynamic per career instead of generic
- Add tag chips to career nodes and preview panel for visual context
- Improve empty states with guided instructions for new users
- Fix hooks ordering to satisfy React rules-of-hooks lint rule

https://claude.ai/code/session_01TKNcrZStyAxzybscLN9L6e